### PR TITLE
[TT-1945] add search route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ CHANGELOG](http://keepachangelog.com/).
 
 ## Unreleased
 
+## 0.3.0
+
+### Added
+- [TT-1945] Add search routes
+
+## 0.2.0
+
 ### Changed
 - [TT-1567] Hack for exclusive products fixed by storing additional details
   (Requires CMS to use ajax login)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 ActionController::Routing::Routes.draw do |map|
   # Page-mounted App
   map.with_options controller: 'page_mount', action: 'proxy' do |page_mount|
-    page_mount.connect 'search/accommodations'
-
     # These are CMS pages:
     # /accommodation/hotel-motel (for each type)
     # /accommodation/kangaroo-island-accommodation/ (for landing page)
@@ -15,6 +13,7 @@ ActionController::Routing::Routes.draw do |map|
 
     page_mount.connect 'transport/*paths'
     page_mount.connect 'tours/*paths'
+    page_mount.connect 'search/*paths'
 
     page_mount.connect 'app_cells/*paths'
 

--- a/radiant-booking_app-extension.gemspec
+++ b/radiant-booking_app-extension.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "radiant-booking_app-extension"
-  spec.version       = '0.1.1'
+  spec.version       = '0.2.0'
   spec.authors       = ["Michael Noack"]
   spec.email         = ["support@travellink.com.au"]
   spec.description   = %q{Integrate booking app with radiant}


### PR DESCRIPTION
Radiant ecom engine should handle other search routes including future ones such as "grid"