### PR TITLE
TT-2897 add ee bundle tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 +This changelog adheres to [Keep a
 CHANGELOG](http://keepachangelog.com/).
 
+## 0.4.0
+
+### Added
+- [TT-2897] Add a tag to retrieve javascript bundles
+
 ## 0.3.1
 
 ### Changed

--- a/lib/tags/script_tags.rb
+++ b/lib/tags/script_tags.rb
@@ -7,4 +7,14 @@ module ScriptTags
     query = "?#{CGI::escape(version.value)}"
     raw %{<script src="/ecom-engine-js/#{tag.attr['src']}#{query}"></script>}
   end
+
+  desc 'Ecom-Engine javascript bundle'
+  tag 'ee_bundle_tag' do |tag|
+    bundle_url = PageMountCalculator.new(@request).ecom_engine_url + "/app_cells?name=header/#{tag.attr['name']}"
+    uri = URI.parse(bundle_url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+    response = http.get uri.request_uri
+    raw response.body.strip
+  end
 end


### PR DESCRIPTION
## Why so we can load javascript bundles using radiant script tags