### PR TITLE
Ensure URL's contain scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 +This changelog adheres to [Keep a
 CHANGELOG](http://keepachangelog.com/).
 
+## Unreleased
+
+### Fixed
+- [TT-3116] Fix case where scheme (http/https) not in ecom engine host
+
 ## 0.4.0
 
 ### Added

--- a/lib/tags/script_tags.rb
+++ b/lib/tags/script_tags.rb
@@ -12,6 +12,7 @@ module ScriptTags
   tag 'ee_bundle_tag' do |tag|
     bundle_url = PageMountCalculator.new(@request).ecom_engine_url + "/app_cells?name=header/#{tag.attr['name']}"
     uri = URI.parse(bundle_url)
+    fail ArgumentError, "web site host must contain http/https" unless %w(https http).include?(uri.scheme)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == 'https'
     response = http.get uri.request_uri


### PR DESCRIPTION
 * This happens in cases where url has no scheme (e.g. blah.com)
   (This only happens in development as in product we need to say https://)
 * Without scheme, the object is a URI::Generic instead of URI::HTTP
   which means it doesn't have the uri.request_uri (needed in this method)